### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -1,5 +1,8 @@
 name: Format and tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/jeandemeusy/api-lib/security/code-scanning/2](https://github.com/jeandemeusy/api-lib/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves checking out code, installing dependencies, running tests, and updating a coverage badge, it only requires `contents: read` and possibly `contents: write` for the badge update. We will add the `permissions` block at the root level of the workflow to apply it to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
