### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,8 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/jeandemeusy/api-lib/security/code-scanning/1](https://github.com/jeandemeusy/api-lib/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `build` job. Since the `build` job only needs to read the repository contents to perform its tasks, we will set `contents: read` as the permission. This change ensures that the job has the minimum required permissions and does not inherit unnecessary write permissions from the repository.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
