### PR TITLE
chore(ci): update workflow trigger to only run on tag pushes

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,10 @@
 name: Publish Python distribution to PyPI
 
-on: push
-
+on:
+  push:
+    tags:
+      - '*'
+      
 jobs:
   build:
     name: Build distribution


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow to run only on tag pushes instead of all push events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->