### PR TITLE
Generate API wrapper from openapi specs

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -23,6 +23,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
+      - name: Install just
+        uses: extractions/setup-just@v3
+        with:
+          just-version: 1.41.0
+
       - name: Install the project
         run: uv sync --locked --all-extras --dev
           
@@ -33,7 +38,7 @@ jobs:
       - name: Test with pytest
         working-directory: .
         run: just test
-
+      
       - name: Update Coverage Badge
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: we-cli/coverage-badge-action@main

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -28,11 +28,11 @@ jobs:
           
       - name: Lint with ruff
         working-directory: .
-        run: make fmt
+        run: just fmt
 
       - name: Test with pytest
         working-directory: .
-        run: make test
+        run: just test
 
       - name: Update Coverage Badge
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ foo*.*
 foo*/
 run_*.sh
 .DS_Store
+
+.generated.*
+*.specs.json

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,5 @@ foo*/
 run_*.sh
 .DS_Store
 
-.generated.*
+generated*
 *.specs.json

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
 .PHONY: fmt
 fmt:
-	@uvx black .
-	@uvx ruff check --output-format=github
-	@uvx ty check
+	@uvx black api_lib test
+	@uvx ruff check api_lib test --output-format=github
+	@uvx ty check api_lib test
 
 .PHONY: test
 test:
 	@uv run pytest --cov=api_lib --cov-report json --cov-report term --cov-report html
 	@find . -name ".coverage*" -not -name ".coveragerc" -delete
+
+.PHONY: specs
+specs:
+	@uv run -m api_lib.from_specs -s .specs.json -n .generated.hoprd

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ from api_lib.objects.response import APIfield, APIobject, JsonResponse
 
 @APIobject
 class User(JsonResponse):
-    login: str = APIfield()
-    name: str = APIfield()
-    disk_usage: int = APIfield()
+    login: str
+    name: str
+    disk_usage: int
     disk_space_limit: int = APIfield("plan/space")
 
 

--- a/api_lib/api_lib.py
+++ b/api_lib/api_lib.py
@@ -300,7 +300,7 @@ class ApiLib:
                     timeout=None,
                 )
             except Exception:
-                await asyncio.sleep(0.25)
+                await asyncio.sleep(0.1)
             else:
                 if is_ok:
                     return is_ok

--- a/api_lib/from_specs/__main__.py
+++ b/api_lib/from_specs/__main__.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+
+import click
+
+from .objects.specs import Specs
+
+
+@click.command()
+@click.option(
+    "--specs",
+    "-s",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Path to the specifications file.",
+)
+@click.option(
+    "--name",
+    "-n",
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+    required=True,
+    help="Path where to store the generated files.",
+)
+def main(specs: Path, name: Path):
+    with specs.open("r") as file:
+        content: dict = json.load(file)
+
+    specifications = Specs(content)
+
+    # create the directory if it does not exist
+    name.mkdir(parents=True, exist_ok=True)
+
+    for key, value in specifications.components.schemas.items():
+        with (name / f"{key}.py").open("w") as file:
+            file.write(value.object_file_content_request(key))
+
+
+if __name__ == "__main__":
+    main()

--- a/api_lib/from_specs/__main__.py
+++ b/api_lib/from_specs/__main__.py
@@ -13,7 +13,7 @@ def write_content_to_file(file: Path, content: Optional[str] = None):
     """Writes the content to a file."""
     if not content:
         content = ""
-        
+
     with file.open("w") as f:
         f.write(content)
 
@@ -50,19 +50,29 @@ def main(specs: Path, name: Path):
         type: ObjectType = ObjectType.RESPONSE if cls_name in specifications.response_objects else ObjectType.REQUEST
         folder: Path = resp_folder if type == ObjectType.RESPONSE else req_folder
 
+        cls_name = cls_name.split("Response")[0]
+        cls_name = cls_name.split("Request")[0]
+
         write_content_to_file(
             folder / f"{lib.snakecase(cls_name)}.py",
             value.object_file_content(cls_name, type),
         )
 
     # Create the api.py file
-    main_file_content = f"""from . import requests, responses\n\n
-class {specifications.info.class_title}:
+    main_file_content = \
+f"""
+from api_lib import ApiLib
+from api_lib.method import Method
+
+from . import requests, responses
+
+
+class {specifications.info.class_title}(ApiLib):
 {'\n'.join([f"\t{line}" for line in specifications.method_strings])}
-    """
+""".strip()
+
     write_content_to_file(name / "api.py", main_file_content)
     write_content_to_file(name / "__init__.py")
-
 
 
 if __name__ == "__main__":

--- a/api_lib/from_specs/__main__.py
+++ b/api_lib/from_specs/__main__.py
@@ -59,8 +59,7 @@ def main(specs: Path, name: Path):
         )
 
     # Create the api.py file
-    main_file_content = \
-f"""
+    main_file_content = f"""
 from api_lib import ApiLib
 from api_lib.method import Method
 

--- a/api_lib/from_specs/__main__.py
+++ b/api_lib/from_specs/__main__.py
@@ -44,23 +44,20 @@ def main(specs: Path, name: Path, prefix: Optional[str]):
     )
 
     # Create request and response files in their respectives folders
-    # write_content_to_file(resp_folder / "__init__.py")
-    # write_content_to_file(req_folder / "__init__.py")
-
     imports_strings = {type: [] for type in ObjectType}
 
     for cls_name, value in specifications.components.schemas.items():
         type: ObjectType = ObjectType.RESPONSE if cls_name in specifications.response_objects else ObjectType.REQUEST
         folder: Path = resp_folder if type == ObjectType.RESPONSE else req_folder
 
-        cls_name = cls_name.split("Response")[0]
-        cls_name = cls_name.split("Request")[0]
+        cls_name = cls_name.split(ObjectType.RESPONSE.value.capitalize())[0]
+
+        imports_strings[type].append(f"from .{lib.snakecase(cls_name)} import {cls_name} as {cls_name}")
 
         write_content_to_file(
             folder / f"{lib.snakecase(cls_name)}.py",
             value.object_file_content(cls_name, type),
         )
-        imports_strings[type].append(f"from .{lib.snakecase(cls_name)} import {cls_name} as {cls_name}")
 
     write_content_to_file(resp_folder / "__init__.py", "\n".join(imports_strings[ObjectType.RESPONSE]))
     write_content_to_file(req_folder / "__init__.py", "\n".join(imports_strings[ObjectType.REQUEST]))

--- a/api_lib/from_specs/__main__.py
+++ b/api_lib/from_specs/__main__.py
@@ -38,12 +38,14 @@ def main(specs: Path, name: Path):
         name / ObjectType.RESPONSE.folder, name / ObjectType.REQUEST.folder
     )
 
-    for cls, value in specifications.components.schemas.items():
-        filename: str = lib.to_snakecase(cls)
-        type: ObjectType = ObjectType.RESPONSE if cls in specifications.response_objects else ObjectType.REQUEST
+    for cls_name, value in specifications.components.schemas.items():
+        type: ObjectType = ObjectType.RESPONSE if cls_name in specifications.response_objects else ObjectType.REQUEST
+        folder: Path = resp_folder if type == ObjectType.RESPONSE else req_folder
 
-        content: str = value.object_file_content(cls, type)
-        write_content_to_file(resp_folder / f"{filename}.py", content)
+        write_content_to_file(
+            folder / f"{lib.snakecase(cls_name)}.py",
+            value.object_file_content(cls_name, type),
+        )
 
 
 if __name__ == "__main__":

--- a/api_lib/from_specs/lib.py
+++ b/api_lib/from_specs/lib.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 
 
 def snakecase(text: str) -> str:
@@ -18,3 +19,26 @@ def manage_directories(*directories: Path):
         directory.mkdir(parents=True, exist_ok=True)
 
     return directories
+
+
+def exported_type(_type: Any) -> str:
+    type_mapping: dict[str, str] = {
+        "string": "str",
+        "integer": "int",
+        "boolean": "bool",
+        "number": "float",
+        "array": "list",
+        "None": "str",
+    }
+
+    if _type and _type not in type_mapping:
+        for key in type_mapping.keys():
+            if str(key) not in _type:
+                continue
+            _type = key
+            break
+
+    if _type and "null" in _type:
+        return f"Optional[{type_mapping.get(_type, 'str')}]"
+    else:
+        return type_mapping.get(str(_type), "") if str(_type) in type_mapping else _type

--- a/api_lib/from_specs/lib.py
+++ b/api_lib/from_specs/lib.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 
-def to_snakecase(text: str) -> str:
+def snakecase(text: str) -> str:
     if text.islower() or not text:
         return text
     return text[0].lower() + "".join("_" + x.lower() if x.isupper() else x for x in text[1:])

--- a/api_lib/from_specs/lib.py
+++ b/api_lib/from_specs/lib.py
@@ -28,10 +28,11 @@ def exported_type(_type: Any) -> str:
         "boolean": "bool",
         "number": "float",
         "array": "list",
+        "object": "dict",
         "None": "str",
     }
 
-    if _type and _type not in type_mapping:
+    if _type and str(_type) not in type_mapping:
         for key in type_mapping.keys():
             if str(key) not in _type:
                 continue

--- a/api_lib/from_specs/lib.py
+++ b/api_lib/from_specs/lib.py
@@ -43,3 +43,23 @@ def exported_type(_type: Any) -> str:
         return f"Optional[{type_mapping.get(_type, 'str')}]"
     else:
         return type_mapping.get(str(_type), "") if str(_type) in type_mapping else _type
+
+
+def split_line_into_multiple_lines(string: str, length: int) -> list[str]:
+    sub_lines = []
+    words = string.split(" ")
+
+    if len(words) == 0:
+        return []
+
+    index = 0
+    while len(words) > 0:
+        sub_lines.append("")
+        while (len(sub_lines[index]) + len(words[0]) + 1) <= length:
+            sub_lines[index] += f" {words.pop(0)}"
+            if len(words) == 0:
+                break
+        sub_lines[index] = sub_lines[index].strip()
+        index += 1
+    
+    return sub_lines

--- a/api_lib/from_specs/lib.py
+++ b/api_lib/from_specs/lib.py
@@ -1,4 +1,20 @@
+from pathlib import Path
+
+
 def to_snakecase(text: str) -> str:
     if text.islower() or not text:
         return text
     return text[0].lower() + "".join("_" + x.lower() if x.isupper() else x for x in text[1:])
+
+
+def manage_directories(*directories: Path):
+    """Create directories if they do not exist, or clear them if they do."""
+    for directory in directories:
+        if directory.exists():
+            for item in directory.iterdir():
+                item.unlink()
+            directory.rmdir()
+
+        directory.mkdir(parents=True, exist_ok=True)
+
+    return directories

--- a/api_lib/from_specs/lib.py
+++ b/api_lib/from_specs/lib.py
@@ -1,0 +1,4 @@
+def to_snakecase(text: str) -> str:
+    if text.islower() or not text:
+        return text
+    return text[0].lower() + "".join("_" + x.lower() if x.isupper() else x for x in text[1:])

--- a/api_lib/from_specs/objects/components.py
+++ b/api_lib/from_specs/objects/components.py
@@ -1,0 +1,81 @@
+from ..lib import to_snakecase
+from .parser import Parser, ParserObject
+
+
+@ParserObject
+class QueryObjectProperty(Parser):
+    type: str
+    example: str
+    format: str
+    example: str
+
+    @property
+    def exported_type(self) -> str:
+        type_mapping: dict[str, str] = {
+            "string": "str",
+            "integer": "int",
+            "boolean": "bool",
+            "number": "float",
+            "array": "list",
+            None: "str",
+        }
+        _type = self.type
+
+        if _type not in type_mapping:
+            for key in type_mapping.keys():
+                if key not in _type:
+                    continue
+                _type = key
+                break
+
+        if _type and "null" in _type:
+            return f"Optional[{type_mapping.get(_type, 'str')}]"
+        else:
+            return type_mapping.get(_type, "str")
+
+
+@ParserObject
+class QueryObjects(Parser):
+    type: str
+    description: str
+    required: list[str]
+    properties: dict[str, QueryObjectProperty]
+
+    def object_file_content_response(self, name: str) -> str:
+        props = self.properties if self.properties else {}
+        body: list[str] = [f"\t{key}: {value.exported_type} = APIfield()" for key, value in props.items()]
+        headers = [
+            "from api_lib.objects.response import APIfield, APIobject, JsonResponse"]
+
+        return self._object_file_content(name, headers, body, ["@APIobject"], ["JsonResponse"])
+
+    def object_file_content_request(self, name: str) -> str:
+        props = self.properties if self.properties else {}
+        body: list[str] = []
+        for key, value in props.items():
+            snake_case = to_snakecase(key)
+            custom_path = f"\"{key}\"" if snake_case != key else ""
+
+            body.append(f"\t{snake_case}: {value.exported_type} = APIfield({custom_path})")
+
+        headers = [
+            "from dataclasses import dataclass",
+            "from api_lib.objects.request import APIfield, RequestData"
+        ]
+        return self._object_file_content(name, headers, body, ["@dataclass"], ["RequestData"])
+
+    def _object_file_content(self, name: str, headers: list[str], body: list[str], decorators: list[str], parent_class: list[str]) -> str:
+        return f"""
+{'\n'.join(headers)}
+
+{'\n'.join(decorators)}
+class {name}({', '.join(parent_class)}):
+\t\"\"\"{self.description.replace("\n", " ")}\"\"\"
+
+{'\n'.join(body)}
+       """.strip()
+
+@ParserObject
+class Components(Parser):
+    schemas: dict[str, QueryObjects]
+    securitySchemes: dict[str, dict]

--- a/api_lib/from_specs/objects/components.py
+++ b/api_lib/from_specs/objects/components.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Optional
 
-from ..lib import snakecase
+from ..lib import exported_type, snakecase
 from .parser import Parser, ParserObject
 
 
@@ -21,30 +21,6 @@ class QueryObjectProperty(Parser):
     example: str
     format: str
     type: str
-
-    @property
-    def exported_type(self) -> str:
-        type_mapping: dict[str, str] = {
-            "string": "str",
-            "integer": "int",
-            "boolean": "bool",
-            "number": "float",
-            "array": "list",
-            None: "str",
-        }
-        _type = self.type
-
-        if _type not in type_mapping:
-            for key in type_mapping.keys():
-                if key not in _type:
-                    continue
-                _type = key
-                break
-
-        if _type and "null" in _type:
-            return f"Optional[{type_mapping.get(_type, 'str')}]"
-        else:
-            return type_mapping.get(_type, "str")
 
 
 @ParserObject
@@ -68,7 +44,7 @@ class QueryObjects(Parser):
         for key, value in props.items():
             exported_key = snakecase(key)
 
-            line = f"\t{exported_key}: {value.exported_type}"
+            line = f"\t{exported_key}: {exported_type(value.type)}"
             if exported_key != key:
                 line += f' = APIfield("{key}")'
             body.append(line)
@@ -82,7 +58,7 @@ class QueryObjects(Parser):
         for key, value in props.items():
             snake_case = snakecase(key)
 
-            line = f"\t{snake_case}: {value.exported_type}"
+            line = f"\t{snake_case}: {exported_type(value.type)}"
 
             params = []
             if snake_case != key:

--- a/api_lib/from_specs/objects/components.py
+++ b/api_lib/from_specs/objects/components.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from ..lib import to_snakecase
+from ..lib import snakecase
 from .parser import Parser, ParserObject
 
 
@@ -71,7 +71,7 @@ class QueryObjects(Parser):
         props = self.properties if self.properties else {}
         body: list[str] = []
         for key, value in props.items():
-            snake_case = to_snakecase(key)
+            snake_case = snakecase(key)
             custom_path = f'"{key}"' if snake_case != key else ""
 
             body.append(f"\t{snake_case}: {value.exported_type} = APIfield({custom_path})")

--- a/api_lib/from_specs/objects/components.py
+++ b/api_lib/from_specs/objects/components.py
@@ -77,7 +77,7 @@ class QueryObjects(Parser):
             body.append(line)
 
         headers = ["from dataclasses import dataclass", "from api_lib.objects.request import APIfield, RequestData"]
-        return self._object_file_content(name, headers, body, ["@dataclass"], ["RequestData"])
+        return self._object_file_content(name, headers, body, ["dataclass"], ["RequestData"])
 
     def _object_file_content(
         self, name: str, headers: list[str], body: list[str], decorators: list[str], parent_class: list[str]

--- a/api_lib/from_specs/objects/infos.py
+++ b/api_lib/from_specs/objects/infos.py
@@ -2,23 +2,9 @@ from .parser import Parser, ParserObject
 
 
 @ParserObject
-class InfosContact(Parser):
-    name: str
-    email: str
-
-
-@ParserObject
-class InfosLicense(Parser):
-    name: str
-    identifier: str
-
-
-@ParserObject
 class Infos(Parser):
     title: str
     description: str
-    contact: InfosContact
-    license: InfosLicense
     version: str
 
     @property

--- a/api_lib/from_specs/objects/infos.py
+++ b/api_lib/from_specs/objects/infos.py
@@ -1,0 +1,22 @@
+from .parser import Parser, ParserObject
+
+
+@ParserObject
+class InfosContact(Parser):
+    name: str
+    email: str
+
+
+@ParserObject
+class InfosLicense(Parser):
+    name: str
+    identifier: str
+
+
+@ParserObject
+class Infos(Parser):
+    title: str
+    description: str
+    contact: InfosContact
+    license: InfosLicense
+    version: str

--- a/api_lib/from_specs/objects/infos.py
+++ b/api_lib/from_specs/objects/infos.py
@@ -20,3 +20,8 @@ class Infos(Parser):
     contact: InfosContact
     license: InfosLicense
     version: str
+
+    @property
+    def class_title(self) -> str:
+        # convert - to _ and then convert to CamelCase
+        return "".join(word.capitalize() for word in self.title.replace("-", "_").split("_"))

--- a/api_lib/from_specs/objects/parser.py
+++ b/api_lib/from_specs/objects/parser.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass, fields, is_dataclass
+from typing import Any, Optional, get_args, get_origin
+
+ParserObject = dataclass(init=False)
+
+
+class Parser:
+    def __init__(self, data: Optional[dict] = None):
+        if data is None:
+            data = {}
+
+        for f in fields(self):
+            field_type = f.type
+            field_name = f.name
+
+            origin: Optional[Any] = get_origin(field_type)
+            args = get_args(field_type)
+            value = data.get(field_name, None)
+
+            if value is None:
+                setattr(self, field_name, None)
+                continue
+
+            if is_dataclass(field_type):
+                value = field_type(value)
+            elif origin is list and len(args) == 1 and is_dataclass(args[0]):
+                value = [args[0](item) if not isinstance(item, args[0]) else item for item in value]
+            elif origin is dict and len(args) == 2 and args[0] is str and is_dataclass(args[1]):
+                value = {k: args[1](v) if not isinstance(v, args[1]) else v for k, v in value.items()}
+            else:
+                args = (*args, field_type)
+                value = args[0](value)
+
+            setattr(self, f.name, value)
+
+    def __repr__(self):
+        key_pair_string: str = ", ".join([f"{key}={value}" for key, value in vars(self).items()])
+        return f"{self.__class__.__name__}({key_pair_string})"

--- a/api_lib/from_specs/objects/paths.py
+++ b/api_lib/from_specs/objects/paths.py
@@ -4,7 +4,7 @@ from .parser import Parser, ParserObject
 @ParserObject
 class Responses(Parser):
     description: str
-    content: dict[str, dict]
+    content: dict
 
 
 @ParserObject
@@ -20,3 +20,6 @@ class Query(Parser):
 class Methods(Parser):
     get: Query
     post: Query
+    delete: Query
+    put: Query
+    patch: Query

--- a/api_lib/from_specs/objects/paths.py
+++ b/api_lib/from_specs/objects/paths.py
@@ -1,0 +1,22 @@
+from .parser import Parser, ParserObject
+
+
+@ParserObject
+class Responses(Parser):
+    description: str
+    content: dict[str, dict]
+
+
+@ParserObject
+class Query(Parser):
+    tags: list[str]
+    summary: str
+    description: str
+    operationId: str
+    responses: dict[str, Responses]
+
+
+@ParserObject
+class Methods(Parser):
+    get: Query
+    post: Query

--- a/api_lib/from_specs/objects/paths.py
+++ b/api_lib/from_specs/objects/paths.py
@@ -6,6 +6,44 @@ class Responses(Parser):
     description: str
     content: dict
 
+    @property
+    def schema(self) -> str:
+        """Returns the schema reference if available."""
+        is_array = False
+        ret_type = None
+        if not self.content:
+            return "bool"
+
+
+        if self.content.get("application/json", None):
+            ret_type = "application/json"
+        elif self.content.get("text/plain", None):
+            ret_type = "text/plain"
+        else:
+            return "NO_APPLICATION_JSON"
+
+        if not self.content[ret_type].get("schema", None):
+            return "NO_SCHEMA"
+
+        if self.content[ret_type]["schema"].get("type", None) == "array":
+            is_array = True
+            ref = self.content[ret_type]["schema"]["items"]["$ref"]
+        elif self.content[ret_type]["schema"].get("$ref", None):
+            ref = self.content[ret_type]["schema"]["$ref"]
+        elif self.content[ret_type]["schema"].get("type", None):
+            ref = self.content[ret_type]["schema"]["type"]
+        else:
+            ref = "NO_REF"
+
+        ref = ref.split("/")[-1] if ref else "NO_REF"
+
+        if ref not in ["string", "integer", "boolean"]:
+            ref = f"responses.{ref}"
+        
+        if is_array:
+            return f"list[{ref}]"
+        else:
+            return ref
 
 @ParserObject
 class Query(Parser):
@@ -15,6 +53,28 @@ class Query(Parser):
     operationId: str
     responses: dict[str, Responses]
 
+    @property
+    def method_name(self) -> str:
+        """Returns the method name in a string format."""
+        return self.operationId.replace("-", "_").replace(" ", "_").lower()
+
+    @property
+    def to_method_string(self) -> list[str]:
+        response = next(
+            (resp for code, resp in self.responses.items() if str(code).startswith("2")),
+            None
+        )
+        if response:
+            ret_type = response.schema
+        else:
+            ret_type = "None"
+
+        """Returns the method name in a string format."""
+        return [
+            f"def {self.method_name}(self) -> {ret_type}:",
+            "\tpass\n"
+        ]
+
 
 @ParserObject
 class Methods(Parser):
@@ -23,3 +83,14 @@ class Methods(Parser):
     delete: Query
     put: Query
     patch: Query
+
+    @property
+    def to_methods_strings(self) -> list[str]:
+        """Returns a list of method names in string format."""
+        methods = []
+        for method in vars(self):
+            query = getattr(self, method)
+            if query is not None:
+                methods.extend(query.to_method_string)
+                
+        return methods

--- a/api_lib/from_specs/objects/paths.py
+++ b/api_lib/from_specs/objects/paths.py
@@ -1,3 +1,4 @@
+from ..lib import exported_type
 from .parser import Parser, ParserObject
 
 
@@ -34,7 +35,7 @@ class Responses(Parser):
         else:
             ref = "NO_REF"
 
-        ref: str = ref.split("/")[-1].rstrip("Response") if ref else "NO_REF"
+        ref: str = ref.split("/")[-1].split("Response")[0] if ref else "NO_REF"
 
         if ref not in ["string", "integer", "boolean"]:
             ref = f"responses.{ref}"
@@ -61,8 +62,9 @@ class Query(Parser):
     def to_method_string(self, path: str, method: str) -> list[str]:
         """Returns the method name in a string format."""
         response = next((resp for code, resp in self.responses.items() if str(code).startswith("2")), None)
+
         if response:
-            ret_type = response.schema
+            ret_type = exported_type(response.schema)
         else:
             ret_type = "None"
 

--- a/api_lib/from_specs/objects/specs.py
+++ b/api_lib/from_specs/objects/specs.py
@@ -18,9 +18,9 @@ class Specs(Parser):
         """Returns a set of all method strings used in the paths."""
         method_strings: list[str] = list()
 
-        for _, methods in self.paths.items():
-            method_strings.extend(methods.to_methods_strings)
-            
+        for path, methods in self.paths.items():
+            method_strings.extend(methods.to_methods_strings(path))
+
         return method_strings
 
     @property

--- a/api_lib/from_specs/objects/specs.py
+++ b/api_lib/from_specs/objects/specs.py
@@ -12,3 +12,31 @@ class Specs(Parser):
     paths: dict[str, Methods]
     components: Components
     tags: list[Tags]
+
+    @property
+    def response_objects(self) -> set[str]:
+        objects: set[str] = set()
+
+        for key, value in self.paths.items():
+            for method in vars(value):
+                query = getattr(value, method)
+
+                if query is None:
+                    continue
+
+                for response in query.responses.values():
+                    if response.content is None:
+                        continue
+
+                    path = ["application/json", "schema", "$ref"]
+
+                    ref = response.content
+                    for part in path:
+                        ref = ref.get(part, None) if ref else None
+
+                    if ref is None:
+                        continue
+
+                    objects.add(ref.split("/")[-1])
+
+        return objects

--- a/api_lib/from_specs/objects/specs.py
+++ b/api_lib/from_specs/objects/specs.py
@@ -1,0 +1,14 @@
+from .components import Components
+from .infos import Infos
+from .parser import Parser, ParserObject
+from .paths import Methods
+from .tags import Tags
+
+
+@ParserObject
+class Specs(Parser):
+    openapi: str
+    info: Infos
+    paths: dict[str, Methods]
+    components: Components
+    tags: list[Tags]

--- a/api_lib/from_specs/objects/specs.py
+++ b/api_lib/from_specs/objects/specs.py
@@ -14,6 +14,16 @@ class Specs(Parser):
     tags: list[Tags]
 
     @property
+    def method_strings(self) -> list[str]:
+        """Returns a set of all method strings used in the paths."""
+        method_strings: list[str] = list()
+
+        for _, methods in self.paths.items():
+            method_strings.extend(methods.to_methods_strings)
+            
+        return method_strings
+
+    @property
     def response_objects(self) -> set[str]:
         objects: set[str] = set()
 

--- a/api_lib/from_specs/objects/tags.py
+++ b/api_lib/from_specs/objects/tags.py
@@ -1,0 +1,7 @@
+from .parser import Parser, ParserObject
+
+
+@ParserObject
+class Tags(Parser):
+    name: str
+    description: str

--- a/api_lib/objects/response.py
+++ b/api_lib/objects/response.py
@@ -2,8 +2,6 @@ from dataclasses import dataclass, field, fields
 from decimal import Decimal
 from typing import Any, Iterable, Optional, get_args, get_origin
 
-"""Defines the Response base class and helpers for API response serialization and metrics."""
-
 APIobject = dataclass(init=False)
 
 

--- a/justfile
+++ b/justfile
@@ -1,14 +1,18 @@
-.PHONY: fmt
+#!/usr/bin/env just --justfile
+
+default: list
+
 fmt:
 	@uvx black api_lib test
 	@uvx ruff check api_lib test --output-format=github
 	@uvx ty check api_lib test
 
-.PHONY: test
 test:
 	@uv run pytest --cov=api_lib --cov-report json --cov-report term --cov-report html
 	@find . -name ".coverage*" -not -name ".coveragerc" -delete
 
-.PHONY: specs
 specs:
 	@uv run -m api_lib.from_specs -s .specs.json -n .generated.hoprd
+
+list:
+	@just --list

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default: list
 
 fmt:
 	@uvx black api_lib test
-	@uvx ruff check api_lib test --output-format=github
+	@uvx ruff check api_lib test --fix --output-format=github
 	@uvx ty check api_lib test
 
 test:

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ test:
 	@find . -name ".coverage*" -not -name ".coveragerc" -delete
 
 specs:
-	@uv run -m api_lib.from_specs -s .specs.json -n .generated.hoprd
+	@uv run -m api_lib.from_specs -s .specs.json -n generated_api --prefix /api/v4
 
 list:
 	@just --list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,10 @@ authors = [{name = "Jean Demeusy", email = "jean.demeusy@hoprnet.org"}]
 maintainers = [{name = "Jean Demeusy", email = "jean.demeusy@hoprnet.org"}]
 classifiers = ["Programming Language :: Python :: 3.13"]
 license = "MIT"
-dependencies = ["aiohttp>=3.12.13"]
+dependencies = [
+    "aiohttp>=3.12.13",
+    "click>=8.2.1",
+]
 
 [project.urls]
 Homepage = "https://github.com/jeandemeusy/api-lib"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ asyncio_default_fixture_loop_scope = "session"
 addopts = ["-ra", "-q"]
 
 log_cli = true
-log_cli_level = "INFO"
+log_cli_level = "CRITICAL"
 log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 

--- a/test/config/request.py
+++ b/test/config/request.py
@@ -5,12 +5,12 @@ from api_lib.objects.request import APIfield, RequestData
 
 @dataclass
 class Pagination(RequestData):
-    per_page: str = APIfield()
-    page: str = APIfield()
+    per_page: str
+    page: str
 
 
 @dataclass
 class RequestClass(RequestData):
-    field: str = APIfield()
+    field: str
     path_field: str = APIfield(api_key="other_key")
     default_field: str = APIfield(default="default_value")

--- a/test/config/response.py
+++ b/test/config/response.py
@@ -9,44 +9,44 @@ from api_lib.objects.response import (
 
 @APIobject
 class Repository(JsonResponse):
-    name: str = APIfield()
+    name: str
     fullname: str = APIfield("full_name")
 
 
 @APIobject
 class User(JsonResponse):
-    login: str = APIfield()
-    name: str = APIfield()
-    disk_usage: int = APIfield()
+    login: str
+    name: str
+    disk_usage: int
     disk_space_limit: int = APIfield("plan/space")
 
 
 @APIobject
 class ResponseClass(JsonResponse):
-    field: str = APIfield()
+    field: str
     path_field: str = APIfield(path="path/to/field")
     default_field: str = APIfield(default="default_value")
 
 
 @APIobject
 class ResponseWithList(JsonResponse):
-    this_list: list[User] = APIfield()
+    this_list: list[User]
 
 
 @APIobject
 class UserWithObject(JsonResponse):
-    user: User = APIfield()
-    repository: Repository = APIfield()
+    user: User
+    repository: Repository
 
 
 @APIobject
 class ResponseWithNestedObjects(JsonResponse):
-    that_list: list[UserWithObject] = APIfield()
+    that_list: list[UserWithObject]
 
 
 @APIobject
 class MetricResponseClass(MetricResponse):
-    metric_one: float = APImetric()
+    metric_one: float
     metric_two: dict = APImetric(["label_name"])
-    metric_three: int = APImetric()
+    metric_three: int
     metric_four: dict = APImetric(["label_name", "other_label_name"])

--- a/uv.lock
+++ b/uv.lock
@@ -75,6 +75,7 @@ name = "api-lib"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "click" },
 ]
 
 [package.dev-dependencies]
@@ -94,7 +95,10 @@ lint = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "aiohttp", specifier = ">=3.12.13" }]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.12.13" },
+    { name = "click", specifier = ">=8.2.1" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI to generate a Python API client from specs JSON (creates request/response models and method stubs).
  * Added Justfile tasks for formatting, testing, specs generation, and listing.

* **Documentation**
  * Simplified model examples in the README to plain type annotations.

* **Chores**
  * Added ignore patterns for generated artifacts and spec JSON files.
  * Removed Makefile fmt/test targets; CI switched to Just and just fmt/test.
  * Added click dependency; reduced pytest log verbosity to CRITICAL.
  * Minor timing tweak in a URL check and removed a module docstring.

* **Tests**
  * Updated test fixtures/examples to use plain type annotations instead of APIfield/APImetric.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->